### PR TITLE
[Introduction] circleci-tfupdate-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,112 +1,17 @@
 version: 2.1
-executors:
-  tfupdate:
-    docker:
-      - image: minamijoyo/tfupdate:latest
-
-commands:
-  git_config:
-    description: Setup git config
-    parameters:
-      user_name:
-        description: git user name
-        type: string
-      user_email:
-        description: git user email
-        type: string
-      github_token:
-        description: environment variable name for GitHub access token
-        type: env_var_name
-        default: GITHUB_TOKEN
-    steps:
-      - run:
-          name: Setup git config
-          command: |
-            git config --local user.name << parameters.user_name >>
-            git config --local user.email << parameters.user_email >>
-            mkdir -p $HOME/.config
-            echo "https://${<< parameters.github_token >>}:@github.com" > $HOME/.config/git-credential
-            git config --local credential.helper "store --file=$HOME/.config/git-credential"
-            git config --local url."https://github.com/".insteadOf 'git@github.com:'
-  tfupdate_terraform:
-    description: Update the terraform to latest
-    parameters:
-      args:
-        description: Arguments for tfupdate command
-        type: string
-        default: "-r ./"
-      base_branch:
-        description: A base branch name to update
-        type: string
-        default: master
-    steps:
-      - run:
-          name: Update terraform to latest
-          command: |
-            VERSION=$(tfupdate release latest hashicorp/terraform)
-            UPDATE_MESSAGE="[tfupdate] Update terraform to v${VERSION}"
-            if hub pr list -s "open" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
-              echo "A pull request already exists"
-            elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
-              echo "A pull request is already merged"
-            else
-              git checkout -b update-terraform-to-v${VERSION} origin/<< parameters.base_branch >>
-              tfupdate terraform -v ${VERSION} << parameters.args >>
-              if git add . && git diff --cached --exit-code --quiet; then
-                echo "No changes"
-              else
-                git commit -m "$UPDATE_MESSAGE"
-                PULL_REQUEST_BODY="For details see: https://github.com/hashicorp/terraform/releases"
-                git push origin HEAD && hub pull-request -m "$UPDATE_MESSAGE" -m "$PULL_REQUEST_BODY" -b << parameters.base_branch >>
-              fi
-            fi
-  tfupdate_provider:
-    description: Update a provider to latest
-    parameters:
-      args:
-        description: Arguments for tfupdate command
-        type: string
-        default: "-r ./"
-      base_branch:
-        description: A base branch name to update
-        type: string
-        default: master
-      provider_name:
-        description: A name of provider
-        type: string
-    steps:
-      - run:
-          name: Update terraform-provider-<< parameters.provider_name >> to latest
-          command: |
-            VERSION=$(tfupdate release latest terraform-providers/terraform-provider-<< parameters.provider_name >>)
-            UPDATE_MESSAGE="[tfupdate] Update terraform-provider-<< parameters.provider_name >> to v${VERSION}"
-            if hub pr list -s "open" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
-              echo "A pull request already exists"
-            elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
-              echo "A pull request is already merged"
-            else
-              git checkout -b update-terraform-provider-<< parameters.provider_name >>-to-v${VERSION} origin/<< parameters.base_branch >>
-              tfupdate provider << parameters.provider_name >> -v ${VERSION} << parameters.args >>
-              if git add . && git diff --cached --exit-code --quiet; then
-                echo "No changes"
-              else
-                git commit -m "$UPDATE_MESSAGE"
-                PULL_REQUEST_BODY="For details see: https://github.com/terraform-providers/terraform-provider-<< parameters.provider_name >>/releases"
-                git push origin HEAD && hub pull-request -m "$UPDATE_MESSAGE" -m "$PULL_REQUEST_BODY" -b << parameters.base_branch >>
-              fi
-            fi
+orbs:
+  tfupdate: masutaka/tfupdate@volatile
 
 jobs:
   tfupdate:
-    executor: tfupdate
+    executor: tfupdate/default
     steps:
       - checkout
-      - run: tfupdate --version
-      - git_config:
-          user_name: 'tfupdate-circleci'
-          user_email: 'minamijoyo+tfupdate-circleci@gmail.com'
-      - tfupdate_terraform
-      - tfupdate_provider:
+      - tfupdate/setup:
+          git_user_name: 'tfupdate-circleci'
+          git_user_email: 'minamijoyo+tfupdate-circleci@gmail.com'
+      - tfupdate/terraform
+      - tfupdate/provider:
           provider_name: 'aws'
 
 workflows:


### PR DESCRIPTION
In Japanese

:bulb: マージを希望する PR ではありません。拙作の Orb 紹介用 PR です。

tfupdate を便利に使わせて頂いております。ありがとうございます！:smile:

tfupdate の CircleCI Orb を作ってみました。
https://circleci.com/orbs/registry/orb/masutaka/tfupdate
└ https://github.com/masutaka/circleci-tfupdate-orb

この PR で分かるように、tfupdate のユーザは記述量が減るので、需要がある気がします。社内では早速需要がありました。:sparkles:

この Orb が提供しているのは executor と command だけです。@minamijoyo さんが紹介した `.terraform-version` の更新等を差し込むことも出来ます（私もやってます）。
https://qiita.com/minamijoyo/items/1350fb28ae82a3dbb354#tfenv

@minamijoyo さんとしても、このリポジトリをメンテナンスするより、Orb をメンテナンスしたほうが楽かもしれません。

もし興味がおありなら、masutaka/tfupdate Orb をお譲りすることは出来ます。Orb はオーナーの変更はできないようなので、masutaka/tfupdate は DEPRECATED という文言を入れて、minamijoyo/tfupdate 等を新規に作って頂く形になります。

普通に https://github.com/masutaka/circleci-tfupdate-orb に PR を下さってももちろん OK です。

先ほど書いた記事です。tfupdate も紹介しています。
[circleci/orb-tools を使った Orb のリリースフローが良く出来ていたので紹介する / マスタカの ChangeLog メモ](https://masutaka.net/chalow/2019-12-20-1.html)