### PR TITLE
Prepare for terraform v0.14

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.13.5"
+  required_version = "0.14.0-beta2"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,10 @@
 terraform {
   required_version = "0.13.5"
-}
 
-provider "aws" {
-  version = "3.15.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.15.0"
+    }
+  }
 }


### PR DESCRIPTION
We probably need to fix an example to support a lock file introduced in Terraform v0.14.
Before it, I moved provider version into required_providers block and updated terraform to v0.14.0-beta2. I'll merge it into master for easy testing.