### PR TITLE
[tfupdate] Update terraform-provider-aws to v3.16.0

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.16.0"
+  constraints = "3.16.0"
+  hashes = [
+    "h1:+Z69RCvJiV6kZqTGqWCj2neVA5G2p5vA4ximwxP/+3A=",
+    "zh:04d4272ed624b7de918205567f3c3a07d1252c2c9604e06c1e7d8326c295d293",
+    "zh:0f278b6975ff6446921410436ed8f3e78bdcd3c6a3a01a392f4f3b73e6e35ac3",
+    "zh:5161dd6802fd57b6af17b6f1e004c210415b89faa885a9b6e5351999c3070a25",
+    "zh:6353ab5bb0e46baec16a6f390efbb77e5a5759759df85c2492478f2da4c64a57",
+    "zh:7571859ab8a234fb5589b995cc586e212d22e7cb7496139ad70911658cadbd69",
+    "zh:7c8cc72b4ea7d6bed76a3ae46ea587d4cdd0a3ead685ef637ad7e3fba0b6effc",
+    "zh:8aa8b7416ba1be27fe213d792185de4be8c75e8375238c952882f0db56a3c531",
+    "zh:8e0691da18db2068b0a7659253af2a0c6ad22c162cd8fd099f63fe75e9d19c56",
+    "zh:b7296b7df2e33858a37f707042ec32bd38390522c9d230f68b33c2a5bb62a6b1",
+    "zh:d024117fdcf4c150875db4ea49a839430f7403ca47f6799c443eca6b7dadc893",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.15.0"
+      version = "3.16.0"
     }
   }
 }


### PR DESCRIPTION
For details see: https://github.com/terraform-providers/terraform-provider-aws/releases