### PR TITLE
[tfupdate] Update terraform-provider-aws to v3.16.0

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,19 +2,20 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.15.0"
-  constraints = "3.15.0"
+  version     = "3.16.0"
+  constraints = "3.16.0"
   hashes = [
-    "h1:/A0Gn4jYyV3KfoxoGnwP9N9+ikpmmYq1pU4xiMUK+6w=",
-    "zh:0478960aece762f5a93ac48a98cf9b905a3d9472bc9774d6a1d5b88ad1ecd8ff",
-    "zh:0b37e4978732377f6475777301e9b2c554bde0953df5a5cf637f4781879d9655",
-    "zh:1abadd84b762aa0fb28a62f0941ae2aaa89e395584fbb22eb47980de41c70659",
-    "zh:26e885c77f744f5125716c5cc23d0465c9e343ea4a6c1097a99f3c3fa2db78f3",
-    "zh:3fceadf566023c68394ba44ad805cc1bb3d7000aba034ca7c57368bbe9cee6ab",
-    "zh:48c5b4f2c062350854a3c989a57490d92828c63fd9f22b76efc2f3e0c37e69a1",
-    "zh:8f2b5b89a4fc019794716878b2a9cf38b633837c21bc4b43e80ef7e5ea4cfffb",
-    "zh:cfab8b257d696084c3160d33b3edbeafc06fc026d09e14c4788ec07a462307ff",
-    "zh:e37f0673b3799693e480c342524b6e4b9387c610cb0a3de82006db58022d492f",
-    "zh:f4ca2b5584fc9d8b0fe68f884b48f680c4b12d4a78352b6b0d482cb88a66717d",
+    "h1:+Z69RCvJiV6kZqTGqWCj2neVA5G2p5vA4ximwxP/+3A=",
+    "h1:Sq3qFYo2K55boeCVsbHd8iC5tuDXul7xwBXwSsd7W/Y=",
+    "zh:04d4272ed624b7de918205567f3c3a07d1252c2c9604e06c1e7d8326c295d293",
+    "zh:0f278b6975ff6446921410436ed8f3e78bdcd3c6a3a01a392f4f3b73e6e35ac3",
+    "zh:5161dd6802fd57b6af17b6f1e004c210415b89faa885a9b6e5351999c3070a25",
+    "zh:6353ab5bb0e46baec16a6f390efbb77e5a5759759df85c2492478f2da4c64a57",
+    "zh:7571859ab8a234fb5589b995cc586e212d22e7cb7496139ad70911658cadbd69",
+    "zh:7c8cc72b4ea7d6bed76a3ae46ea587d4cdd0a3ead685ef637ad7e3fba0b6effc",
+    "zh:8aa8b7416ba1be27fe213d792185de4be8c75e8375238c952882f0db56a3c531",
+    "zh:8e0691da18db2068b0a7659253af2a0c6ad22c162cd8fd099f63fe75e9d19c56",
+    "zh:b7296b7df2e33858a37f707042ec32bd38390522c9d230f68b33c2a5bb62a6b1",
+    "zh:d024117fdcf4c150875db4ea49a839430f7403ca47f6799c443eca6b7dadc893",
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.15.0"
+      version = "3.16.0"
     }
   }
 }


### PR DESCRIPTION
For details see: https://github.com/terraform-providers/terraform-provider-aws/releases