### PR TITLE
Fix udpating .terraform.lock.hcl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,22 +100,8 @@ commands:
               wget -qO- https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | unzip -d /bin - && chmod +x /bin/terraform
               terraform version
 
-              # create a local filesystem mirror to avoid duplicate downloads
-              FS_MIRROR="/tmp/terraform.d/plugins"
-              terraform providers mirror -platform=linux_amd64 -platform=darwin_amd64 "${FS_MIRROR}"
-
-              # update the lock file
-              ALL_DIRS=$(find . -type f -name '*.tf' | xargs -I {} dirname {} | grep -v 'modules/')
-              for dir in ${ALL_DIRS}
-              do
-                pushd "$dir"
-                # always create a new lock to avoid duplicate downloads by terraoform init -upgrade
-                rm -f .terraform.lock.hcl
-                # generate h1 hashes for all platforms you need
-                # recording zh hashes requires to download from origin, so we intentionally ignore them.
-                terraform providers lock -fs-mirror="${FS_MIRROR}" -platform=linux_amd64 -platform=darwin_amd64
-                popd
-              done
+              # generate .terraform.lock.hcl
+              bin/tflock_generate.sh
 
               if git add . && git diff --cached --exit-code --quiet; then
                 echo "No changes"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,10 @@ commands:
             else
               git checkout -b update-terraform-to-v${VERSION} origin/<< parameters.base_branch >>
               tfupdate terraform -v ${VERSION} << parameters.args >>
+
+              # update CircleCI (tfupdate_provider)
+              sed -i -E "s#terraform_version: \'[0-9]+(\.[0-9]+)*(-.*)*\'#terraform_version: \'$VERSION\'#" .circleci/config.yml
+
               if git add . && git diff --cached --exit-code --quiet; then
                 echo "No changes"
               else

--- a/bin/tflock_generate.sh
+++ b/bin/tflock_generate.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -eo pipefail
 
+# create a plugin cache dir
+export TF_PLUGIN_CACHE_DIR="/tmp/terraform.d/plugin-cache"
+mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+
 # create a local filesystem mirror to avoid duplicate downloads
 FS_MIRROR="/tmp/terraform.d/plugins"
 terraform providers mirror -platform=linux_amd64 -platform=darwin_amd64 "${FS_MIRROR}"
@@ -12,8 +16,14 @@ do
   pushd "$dir"
   # always create a new lock to avoid duplicate downloads by terraoform init -upgrade
   rm -f .terraform.lock.hcl
+  # get modules to detect provider dependencies inside module
+  terraform init -input=false -no-color -backend=false -plugin-dir="${FS_MIRROR}"
+  # remove a temporary lock file to avoid a checksum mismatch error
+  rm -f .terraform.lock.hcl
   # generate h1 hashes for all platforms you need
   # recording zh hashes requires to download from origin, so we intentionally ignore them.
   terraform providers lock -fs-mirror="${FS_MIRROR}" -platform=linux_amd64 -platform=darwin_amd64
+  # clean up
+  rm -rf .terraform
   popd
 done

--- a/bin/tflock_generate.sh
+++ b/bin/tflock_generate.sh
@@ -6,7 +6,7 @@ FS_MIRROR="/tmp/terraform.d/plugins"
 terraform providers mirror -platform=linux_amd64 -platform=darwin_amd64 "${FS_MIRROR}"
 
 # update the lock file
-ALL_DIRS=$(find . -type f -name '*.tf' | xargs -I {} dirname {} | grep -v 'modules/')
+ALL_DIRS=$(find . -type f -name '*.tf' | xargs -I {} dirname {} | sort | uniq | grep -v 'modules/')
 for dir in ${ALL_DIRS}
 do
   pushd "$dir"

--- a/bin/tflock_generate.sh
+++ b/bin/tflock_generate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eo pipefail
+
+# create a local filesystem mirror to avoid duplicate downloads
+FS_MIRROR="/tmp/terraform.d/plugins"
+terraform providers mirror -platform=linux_amd64 -platform=darwin_amd64 "${FS_MIRROR}"
+
+# update the lock file
+ALL_DIRS=$(find . -type f -name '*.tf' | xargs -I {} dirname {} | grep -v 'modules/')
+for dir in ${ALL_DIRS}
+do
+  pushd "$dir"
+  # always create a new lock to avoid duplicate downloads by terraoform init -upgrade
+  rm -f .terraform.lock.hcl
+  # generate h1 hashes for all platforms you need
+  # recording zh hashes requires to download from origin, so we intentionally ignore them.
+  terraform providers lock -fs-mirror="${FS_MIRROR}" -platform=linux_amd64 -platform=darwin_amd64
+  popd
+done


### PR DESCRIPTION
On top of #113, Fixed some minor issues:

- Move generating .terraform.lock.hcl logic to tflock_generate.sh
- Uniq duplicated loops 
- Update terraform_version attribute for tfupdate_provider automatically
- Get modules to detect provider dependencies inside module

