### PR TITLE
[tfupdate] Update terraform-provider-aws to v3.29.1

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,10 +2,10 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.20.0"
-  constraints = "3.20.0"
+  version     = "3.29.1"
+  constraints = "3.29.1"
   hashes = [
-    "h1:3M0q/GqB24RM5E1wIu23bEbChJ2RDVaM5lTLENB92Cc=",
-    "h1:Wk7JYiEIslHQorVPWnofRNYUAjyro6IehY/d/Yfmbr8=",
+    "h1:RGjj+AQ36r8UMMa5fRWrQ8ONeMe6z31UXVAYQhPTH2s=",
+    "h1:vFaEB2VBkZnKUXuVbOLbq6a8mOYNx2ftmTRP0YVbzu8=",
   ]
 }

--- a/dev/.terraform.lock.hcl
+++ b/dev/.terraform.lock.hcl
@@ -2,10 +2,10 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.20.0"
-  constraints = "3.20.0"
+  version     = "3.29.1"
+  constraints = "3.29.1"
   hashes = [
-    "h1:3M0q/GqB24RM5E1wIu23bEbChJ2RDVaM5lTLENB92Cc=",
-    "h1:Wk7JYiEIslHQorVPWnofRNYUAjyro6IehY/d/Yfmbr8=",
+    "h1:RGjj+AQ36r8UMMa5fRWrQ8ONeMe6z31UXVAYQhPTH2s=",
+    "h1:vFaEB2VBkZnKUXuVbOLbq6a8mOYNx2ftmTRP0YVbzu8=",
   ]
 }

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.20.0"
+      version = "3.29.1"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.20.0"
+      version = "3.29.1"
     }
   }
 }

--- a/prod/.terraform.lock.hcl
+++ b/prod/.terraform.lock.hcl
@@ -2,10 +2,10 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.20.0"
-  constraints = "3.20.0"
+  version     = "3.29.1"
+  constraints = "3.29.1"
   hashes = [
-    "h1:3M0q/GqB24RM5E1wIu23bEbChJ2RDVaM5lTLENB92Cc=",
-    "h1:Wk7JYiEIslHQorVPWnofRNYUAjyro6IehY/d/Yfmbr8=",
+    "h1:RGjj+AQ36r8UMMa5fRWrQ8ONeMe6z31UXVAYQhPTH2s=",
+    "h1:vFaEB2VBkZnKUXuVbOLbq6a8mOYNx2ftmTRP0YVbzu8=",
   ]
 }

--- a/prod/main.tf
+++ b/prod/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.20.0"
+      version = "3.29.1"
     }
   }
 }


### PR DESCRIPTION
For details see: https://github.com/terraform-providers/terraform-provider-aws/releases