### PR TITLE
Revert "Use the git command for getting the latest release as a workaround"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,7 @@ commands:
       - run:
           name: Update terraform to latest
           command: |
-            # A workaround for getting the latest release issue
-            # https://github.com/minamijoyo/tfupdate/issues/36
-            # VERSION=$(tfupdate release latest hashicorp/terraform)
-            VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --tags --sort='v:refname' https://github.com/hashicorp/terraform | tail -n 1 | cut -d'/' -f3 | sed s/^v//)
+            VERSION=$(tfupdate release latest hashicorp/terraform)
             UPDATE_MESSAGE="[tfupdate] Update terraform to v${VERSION}"
             if hub pr list -s "open" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
               echo "A pull request already exists"
@@ -89,8 +86,7 @@ commands:
       - run:
           name: Update terraform-provider-<< parameters.provider_name >> to latest
           command: |
-            # VERSION=$(tfupdate release latest terraform-providers/terraform-provider-<< parameters.provider_name >>)
-            VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --tags --sort='v:refname' https://github.com/terraform-providers/terraform-provider-<< parameters.provider_name >> | tail -n 1 | cut -d'/' -f3 | sed s/^v//)
+            VERSION=$(tfupdate release latest terraform-providers/terraform-provider-<< parameters.provider_name >>)
             UPDATE_MESSAGE="[tfupdate] Update terraform-provider-<< parameters.provider_name >> to v${VERSION}"
             if hub pr list -s "open" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
               echo "A pull request already exists"
@@ -103,8 +99,7 @@ commands:
               # install terraform
               TERRAFORM_VERSION=<< parameters.terraform_version >>
               if [ "${TERRAFORM_VERSION}" = "latest" ]; then
-                # TERRAFORM_VERSION=$(tfupdate release latest hashicorp/terraform)
-                TERRAFORM_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --tags --sort='v:refname' https://github.com/hashicorp/terraform | tail -n 1 | cut -d'/' -f3 | sed s/^v//)
+                TERRAFORM_VERSION=$(tfupdate release latest hashicorp/terraform)
               fi
               wget -qO- https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | unzip -d /bin - && chmod +x /bin/terraform
               terraform version


### PR DESCRIPTION
Reverts minamijoyo/tfupdate-circleci-example#159

The issue https://github.com/minamijoyo/tfupdate/issues/36 was fixed in https://github.com/minamijoyo/tfupdate/pull/41.
The workaround is no longer needed.